### PR TITLE
Model merge fixed

### DIFF
--- a/src/main/java/org/hobbit/sdk/utils/ModelsHandler.java
+++ b/src/main/java/org/hobbit/sdk/utils/ModelsHandler.java
@@ -72,10 +72,7 @@ public class ModelsHandler {
                 if(experimentResource.getProperty(parameter)==null){
                     objIterator = defaultModel.listObjectsOfProperty(parameter, defaultValProperty);
                     while (objIterator.hasNext()) {
-                        Literal valueLiteral = (Literal) objIterator.next();//.asLiteral().getString();
-                        //paramsModel.add(experimentResource, parameter, valueLiteral.getString(), valueLiteral.getDatatype());
-                        paramsModel.add(experimentResource, parameter, valueLiteral.getString());
-                        //parameters.put(namespaceUri + "#" + parameter.getLocalName(), value);
+                        paramsModel.add(experimentResource, parameter, objIterator.next());
                     }
                 }
             }


### PR DESCRIPTION
Fixed the merging of RDF models to allow other default values than literals.

This fixes the following exception:
```
java.lang.ClassCastException: org.apache.jena.rdf.model.impl.ResourceImpl cannot be cast to org.apache.jena.rdf.model.Literal
	at org.hobbit.sdk.utils.ModelsHandler.createMergedParametersModel(ModelsHandler.java:75)
	at org.dice_research.ldcbench.BenchmarkTestBase.executeBenchmark(BenchmarkTestBase.java:120)
	at org.dice_research.ldcbench.BenchmarkIT.executeBenchmark(BenchmarkIT.java:16)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.internal.runners.TestMethodRunner.executeMethodBody(TestMethodRunner.java:99)
	at org.junit.internal.runners.TestMethodRunner.runUnprotected(TestMethodRunner.java:81)
	at org.junit.internal.runners.BeforeAndAfterRunner.runProtected(BeforeAndAfterRunner.java:34)
	at org.junit.internal.runners.TestMethodRunner.runMethod(TestMethodRunner.java:75)
	at org.junit.internal.runners.TestMethodRunner.run(TestMethodRunner.java:45)
	at org.junit.internal.runners.TestClassMethodsRunner.invokeTestMethod(TestClassMethodsRunner.java:66)
	at org.junit.internal.runners.TestClassMethodsRunner.run(TestClassMethodsRunner.java:35)
	at org.junit.internal.runners.TestClassRunner$1.runUnprotected(TestClassRunner.java:42)
	at org.junit.internal.runners.BeforeAndAfterRunner.runProtected(BeforeAndAfterRunner.java:34)
	at org.junit.internal.runners.TestClassRunner.run(TestClassRunner.java:52)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)
```